### PR TITLE
chore(docs): README + Claude/Cursor — org Project cookie

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,3 +14,14 @@
 - Спецификация в **vault**, не копировать простыни SRS в PR/issues.
 - Issues: поля формы `.github/ISSUE_TEMPLATE/task.yml`, блок **Trace** обязателен для связи с FR.
 - Диаграммы и зеркало репозитория **architecture**: [github.com/COOKieProjectTeam/architecture](https://github.com/COOKieProjectTeam/architecture).
+
+### API / качество перед PR
+
+- **Платформа:** **ASP.NET Core 8**, REST поверх версионированных маршрутов (канонический префикс **`api/v1`**, см. SRS/архитектурное зеркало); не добавлять несогласованные версии без trace в issue и обновления спеки/vault при необходимости.
+- **Документация контрактов:** локально при запущенном API — Swagger UI типично на **`/swagger`** (конкретный путь см. код `Program.cs`/регистрация OpenAPI по мере появления приложения в репо).
+- **Health:** при наличии production-oriented endpoints держите отдельно liveness/readiness и не сваливать в них бизнес-логику.
+- **От issue к коду:** в PR явная связь (`Refs`/`Closes`); затем соответствие **Trace ↔ контроллер/сервис ↔ тесты** (юнит/интеграционные там, где заведены в решении).
+
+### Организационная доска
+
+- Единый org Projects **«cookie»**, workflow добавления issue: см. [github-project-cookie](https://github.com/COOKieProjectTeam/architecture/blob/main/docs/process/github-project-cookie.md).

--- a/.claude/rules/sot-and-issues.md
+++ b/.claude/rules/sot-and-issues.md
@@ -12,6 +12,8 @@
 
 Форма: `.github/ISSUE_TEMPLATE/task.yml`.
 
+См. также org-проект **«cookie»** и метки `area:*` — [github-project-cookie](https://github.com/COOKieProjectTeam/architecture/blob/main/docs/process/github-project-cookie.md).
+
 ## Pull Request
 
 - **`main`** защищён на GitHub: работа только в отдельной ветке и через **Pull Request**. Подробно: `.claude/rules/protected-main.md`.

--- a/.cursor/rules/cookie-backend.mdc
+++ b/.cursor/rules/cookie-backend.mdc
@@ -15,11 +15,13 @@ alwaysApply: false
 - **Тексты требований и архитектуры (канон):** Obsidian vault — `Knowledge/Development/Projects/COOKie/` на машине автора (не дублировать BRD/SRS в коде или issues полностью).
 - **Формат issues и Trace:** см. описание полей в `.github/ISSUE_TEMPLATE/task.yml` и блок **Goal / Scope / Trace / Acceptance / Companion**; ориентир процесса в vault: `Knowledge/Development/Projects/COOKie/process/github-issue-format.md`.
 - **Техстек канон:** тот же путь vault — `architecture/technical/tech-stack.md` (ASP.NET Core **8**, EF Core **8**, PostgreSQL **15**, Redis **7**, REST + JWT + **swagger**, FluentValidation и т.д.). При конфликте с `package.json`/кодом — приоритет **документ vault** или заведите issue на CR к спеки.
+- **Цитирование SRS в PR не заменяет Trace в issue:** сверяйтесь с vault, текстом задачи (**Trace**/**Vault:**), swagger и утверждёнными траекториями кода после появления артефактов в этом репо.
 
 ## Практика
 
 - Контракт API согласовывать с фронтом; в задачах указывать **Companion** на issue в `cookie-frontend` при вертикали.
 - Не расширять scope без явного согласования (в т.ч. смена FW вне канона из tech-stack).
+- **Доска org:** Projects **«cookie»** ([ссылка](https://github.com/orgs/COOKieProjectTeam/projects/2)); метки **`area:backend`** / **`area:frontend`** по полю работы где уместно, плюс **`area:infra`**, **`area:docs`**; процесс см. [github-project-cookie](https://github.com/COOKieProjectTeam/architecture/blob/main/docs/process/github-project-cookie.md).
 
 ## Защищённый `main`
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# COOKie Backend
+
+ASP.NET Core API сервис проекта COOKie (organization [COOKieProjectTeam/cookie-backend](https://github.com/COOKieProjectTeam/cookie-backend)).
+
+Канон технологического стека и API — см. зеркало в репозитории [architecture](https://github.com/COOKieProjectTeam/architecture): `docs/architecture/technical/tech-stack.md` и спеки в `docs/requirements/` (ветка **`main`**).
+
+Workflow и защита ветки `main`: [.claude/rules/protected-main.md](.claude/rules/protected-main.md).
+
+## GitHub Project · Actions
+
+Созданная в этом репозитории **issue** добавляется в org Projects v2 **[«cookie»](https://github.com/orgs/COOKieProjectTeam/projects/2)** workflow [`.github/workflows/add-issue-to-org-project.yml`](.github/workflows/add-issue-to-org-project.yml). Нужен репозиторный секрет **`ADD_TO_PROJECT_PAT`** — см. [github-project-cookie](https://github.com/COOKieProjectTeam/architecture/blob/main/docs/process/github-project-cookie.md) в **architecture**.
+
+## Локально
+
+Структура кода добавляется по мере реализации; после появления `Program.cs`/swagger файл README дополним командами `dotnet run` и базовым URL документации API.


### PR DESCRIPTION
- New \README.md\ (links to architecture, protected main).\n- Extends \.claude/CLAUDE.md\ (ASP.NET Core 8, swagger, versioning, checklist).\n- \sot-and-issues.md\, \cookie-backend.mdc\: org project + \rea:*\.\n\nWorkflow YAML: same \workflow\-scope caveat; duplicate commit available locally on \cookie-backend\ history as branch \chore/org-project-actions-and-rules\ first commit—or copy from architecture doc.