### PR TITLE
chore: add PR template for backend

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+# Pull Request
+
+## Summary
+<!-- Brief description of what this PR does -->
+
+## Changes
+<!-- List of changes made in this PR -->
+-
+-
+-
+
+## Architecture Reference
+<!-- Link to relevant architecture documentation (if applicable) -->
+<!-- Example: https://github.com/COOKieProjectTeam/architecture/blob/main/docs/requirements/SRS.md §... -->
+
+## Type of Change
+<!-- Mark with "x" the relevant option(s) -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] Configuration/infrastructure change
+- [ ] Database migration
+
+## Checklist
+<!-- Mark with "x" all that apply -->
+- [ ] Code follows project style guide (`dotnet format` clean)
+- [ ] Self-review completed
+- [ ] Non-obvious logic has a comment explaining WHY (not what)
+- [ ] OpenAPI / Swagger updated for any new or changed endpoints
+- [ ] EF Core migration included (if schema changed)
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated (if HTTP endpoint changed)
+- [ ] No secrets or connection strings committed
+
+## Related Issues
+<!-- Link related issues using keywords: Closes, Fixes, Resolves, Implements, Related -->
+<!-- Example: Closes #10, Refs https://github.com/COOKieProjectTeam/architecture/blob/main/docs/requirements/SRS.md -->
+
+
+## Additional Notes
+<!-- Any additional information for reviewers -->


### PR DESCRIPTION
## Summary
- Adds `.github/PULL_REQUEST_TEMPLATE.md` with backend-specific checklist (`dotnet format`, OpenAPI, EF Core migration, no secrets)

## Type of Change
- [x] Configuration/infrastructure change

## Related Issues
Left over from `chore/claude-rules` branch — PR template was never merged to main.