### PR TITLE
chore: api-spec-export skill, workflow doc, CLAUDE.md path fix

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,7 +17,7 @@ dotnet ef database update           # применить миграции
 
 1. [.claude/rules/protected-main.md](rules/protected-main.md) — **`main`** защищённая ветка: ветка → push → **PR → `main`**; в PR указать связь с **issue** (`Closes` / `Refs #N`).
 2. [.claude/rules/sot-and-issues.md](rules/sot-and-issues.md) — источники правды и формат задач.
-3. Канон стека и API: репозиторий [architecture](https://github.com/COOKieProjectTeam/architecture) — `docs/technical/tech-stack.md` и `docs/requirements/FRS.md`.
+3. Канон стека и API: репозиторий [architecture](https://github.com/COOKieProjectTeam/architecture) — `docs/architecture/technical/tech-stack.md` и `docs/requirements/FRS.md`.
 
 ## Архитектура
 

--- a/.claude/skills/api-spec-export/SKILL.md
+++ b/.claude/skills/api-spec-export/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: api-spec-export
+description: Export the running API's OpenAPI/Swagger spec into a versioned artifact under docs/api/, so the frontend /api-client skill can consume it without hitting a live server. Use after API contract changes (new endpoints, DTO updates, breaking renames).
+argument-hint: "[version-tag]"
+disable-model-invocation: true
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash(dotnet build*)
+  - Bash(dotnet run*)
+  - Bash(curl*)
+  - Bash(git status)
+  - Bash(git diff*)
+  - Bash(git add*)
+---
+
+Export the live OpenAPI document from the running ASP.NET Core API and commit it to `docs/api/` as a versioned artifact. Mirror of frontend `/api-client` — frontend consumes what this skill produces.
+
+## Why this exists
+
+Frontend `/api-client` skill needs a swagger source. Hitting a live dev server is brittle (env down, drift between branches). A checked-in `docs/api/openapi.json` is reproducible and reviewable in PRs.
+
+## Inputs
+
+- `$ARGUMENTS`: optional version tag. Examples: `v1`, `2026-05-08`, `sprint-01`. Defaults to `v1`.
+- The skill assumes `src/CookieApi/` (or whatever the API project is named) exposes Swashbuckle and serves `/swagger/v1/swagger.json`.
+
+## Step 1: Discover the API project and Swagger endpoint
+
+- Glob `**/*.csproj` to find the API project.
+- Read its `Program.cs` to confirm Swagger is registered (`AddSwaggerGen` / `UseSwagger`).
+- Identify the swagger doc URL. Default Swashbuckle path: `/swagger/v1/swagger.json`.
+- If no Swagger configured: STOP. Tell the user to add Swashbuckle to the API project first; do not silently proceed.
+
+## Step 2: Pick export strategy
+
+Two options. Prefer (A) when scaffold supports it:
+
+**(A) Build-time export via `Swashbuckle.AspNetCore.Cli`** (preferred — no dev server needed):
+
+- Check if `Swashbuckle.AspNetCore.Cli` is referenced.
+- If not, propose adding it: `dotnet tool install --global Swashbuckle.AspNetCore.Cli` and a project reference.
+- Run: `swagger tofile --output docs/api/openapi.json src/CookieApi/bin/Debug/net8.0/CookieApi.dll v1`
+- This requires a successful `dotnet build` first.
+
+**(B) Runtime export** (fallback — when CLI tool not available):
+
+- Start the API in background: `dotnet run --project src/CookieApi --no-launch-profile`.
+- Wait for readiness (poll `/health` or `/swagger/v1/swagger.json` with retry).
+- `curl -sf http://localhost:5000/swagger/v1/swagger.json -o docs/api/openapi.json`.
+- Stop the background process cleanly.
+
+ASK the user which strategy to use if both are viable.
+
+## Step 3: Normalize the output
+
+- Pretty-print JSON (4-space indent) so diffs in PRs are readable: `jq '.' docs/api/openapi.json > tmp && mv tmp docs/api/openapi.json`.
+- Strip volatile fields that change every export but carry no contract value:
+  - `info.version` if it's a build-time GUID/timestamp — replace with the `$ARGUMENTS` tag.
+  - Server URLs that include random ports — normalize to `https://api.cookie.test/api/v1`.
+- Do NOT strip schema definitions, paths, or operationIds.
+
+## Step 4: Versioned snapshot (optional)
+
+- Always keep `docs/api/openapi.json` as the latest.
+- If `$ARGUMENTS` provided, also write `docs/api/openapi-<tag>.json` as an immutable snapshot. This lets PR reviewers compare versions.
+
+## Step 5: Diff review
+
+- Run `git diff docs/api/openapi.json` and surface to the user:
+  - **Added paths** — new endpoints (likely safe additive change).
+  - **Removed paths** — breaking change. Flag explicitly.
+  - **Changed schemas** — for each, classify: additive (new optional field) vs breaking (renamed field, type change, required added).
+- Categorize the diff at the top of the response:
+  - `[additive]` — frontend can pull without code changes
+  - `[breaking]` — frontend must update; flag the consuming `entities/<domain>/` slices to fix
+
+## Step 6: Hand-off
+
+- Commit message proposal: `docs(api): export openapi <tag>` or `docs(api): export openapi (breaking: removed POST /api/v1/x)`.
+- Tell the user to run `/api-client <domain>` on the frontend repo for any domain whose schema changed.
+
+## Rules
+
+- Never edit `docs/api/openapi.json` by hand — always re-export.
+- Never commit a spec that fails `jq empty docs/api/openapi.json` (broken JSON).
+- Never silently strip operations, paths, or schemas during normalization.
+- If the live server returns non-200, STOP with the exact error. Do not write a partial spec.
+- If `dotnet build` fails, STOP. The spec must reflect a building API.
+- This skill is read-only against the API code itself — never modify controllers, DTOs, or Program.cs to "fix" spec issues. Surface the issue and let the user fix the source.

--- a/docs/workflow-backend.md
+++ b/docs/workflow-backend.md
@@ -1,0 +1,205 @@
+# Workflow для cookie-backend
+
+Инструкция по работе с Claude Code в этом репозитории: какие агенты, скиллы, хуки и правила настроены и как их собирать в единый цикл фичи.
+
+Стек: **.NET 8 + ASP.NET Core 8 + EF Core 8 + Identity + JWT + FluentValidation + PostgreSQL 15 + xUnit + Swashbuckle**.
+
+> **Главное условие:** открывать VS Code в корне `cookie-backend` (не `COOK/`). Иначе `.claude/settings.json` не подхватывается, hooks не цепляются, skills не видны.
+
+## 1. Что лежит в `.claude/`
+
+### Agents (`.claude/agents/`)
+
+| Агент | Назначение |
+|---|---|
+| `api-designer` | REST контракты — routes, DTOs, controllers, status codes по конвенциям проекта |
+| `code-reviewer` | Общий ревью изменений |
+| `security-reviewer` | AuthZ/AuthN, инъекции, secrets, JWT валидация |
+| `performance-reviewer` | EF Core N+1, async/await, аллокации, индексы |
+| `doc-reviewer` | XML-doc, README, комментарии |
+
+### Skills (`.claude/skills/<name>/SKILL.md`, вызов как `/<name>`)
+
+| Скилл | Что делает |
+|---|---|
+| `/api-spec-export` | Выгружает OpenAPI спеку в `docs/api/openapi.json` для consume фронтендом |
+| `/test-writer` | xUnit тесты под изменённый код |
+| `/tdd` | Red → green → refactor цикл |
+| `/pr-review` | Параллельный прогон reviewer-агентов |
+| `/refactor` | Безопасный рефактор без смены поведения |
+| `/debug-fix` | Гипотеза → repro → фикс |
+| `/explain` | Объяснение участка кода |
+| `/ship` | git status → commit → push → PR (с подтверждением на каждом шаге) |
+
+### Hooks (`.claude/hooks/`)
+
+| Хук | Триггер | Что делает |
+|---|---|---|
+| `protect-files.sh` | PreToolUse Edit/Write | Блок Edit/Write на `.env*`, `*.pem`, `*.key`, `appsettings*.Production.json` без явного approve |
+| `scan-secrets.sh` | PreToolUse Edit/Write | Ловит хардкод connection strings, JWT секретов, API ключей |
+| `warn-large-files.sh` | PreToolUse Edit/Write | Отстреливает попытку коммитить `bin/`, `obj/`, `*.user` |
+| `block-dangerous-commands.sh` | PreToolUse Bash | Режет `rm -rf`, `git push --force` в main, `dotnet ef database drop`, `dotnet nuget push` |
+| `format-on-save.sh` | PostToolUse Edit/Write | `dotnet format` после правок `.cs` файлов |
+| `session-start.sh` | SessionStart | Подгружает контекст в начале сессии |
+| `notify.sh` | Notification | Системные уведомления |
+
+### Rules (`.claude/rules/`, автозагрузка в контекст)
+
+| Файл | Что внутри |
+|---|---|
+| `protected-main.md` | `main` защищён, только PR |
+| `sot-and-issues.md` | SoT — repo `architecture`, формат GitHub issue |
+| `backend.md` | Clean Architecture слои, EF Core конвенции, DI, async/await |
+| `code-quality.md`, `error-handling.md`, `security.md`, `testing.md` | Поперечные правила |
+
+### Permissions (`settings.json`, allow без подтверждения)
+
+`dotnet build|run|test|format|ef|add|remove|restore|clean`, весь `git *`, `gh pr|issue|run`. Всё остальное — спросит.
+
+`Read/Write/Edit` на `.env*`, `*.pem`, `*.key`, `secrets/**` — **deny**.
+
+## 2. Workflow на реальном примере
+
+**Sprint 01, задача [BE#10](https://github.com/COOKieProjectTeam/cookie-backend/issues/10): JWT auth (FR-US-001).**
+
+### Шаг 1. API дизайн
+
+```
+Ты:  /api-designer спроектируй endpoints для регистрации,
+     логина и refresh по FR-US-001
+```
+
+`api-designer` возвращает:
+
+- **Route table:**
+  ```
+  POST /api/v1/auth/register   201 → AuthResponse
+  POST /api/v1/auth/login      200 → AuthResponse
+  POST /api/v1/auth/refresh    200 → AuthResponse  (Cookie: refreshToken)
+  POST /api/v1/auth/logout     204
+  ```
+- **DTO records:** `RegisterRequest`, `LoginRequest`, `AuthResponse(string AccessToken)`.
+- **Controller stub:** `AuthController` с `[ApiController]`, `[Route("api/v1/[controller]")]`.
+- **Application layer sketch:** `RegisterUserCommand`, `LoginCommand`, `RefreshTokenCommand` + handlers.
+- **Open questions:** lockout policy? token TTL (access vs refresh)? rate limit на register?
+
+### Шаг 2. Реализация
+
+```
+Ты:  ok, access TTL 15min, refresh 30 days. Lockout 5 attempts/15min. Реализуй
+```
+
+Claude пишет код. Hooks работают незаметно:
+- `format-on-save.sh` гоняет `dotnet format` после каждого Write
+- `scan-secrets.sh` сработает если случайно закоммитишь `Issuer` / `Audience` / signing key в код вместо `appsettings.json`
+- `protect-files.sh` не даст тронуть `appsettings.Production.json`
+
+### Шаг 3. Миграция
+
+```
+Ты:  dotnet ef migrations add AddIdentitySchema
+```
+
+`block-dangerous-commands.sh` пропустит. `database update` тоже разрешён, но `database drop` — заблокирован.
+
+### Шаг 4. Тесты
+
+```
+Ты:  /test-writer
+```
+
+xUnit + `WebApplicationFactory` интеграционные тесты для:
+- `POST /register` — happy path, дубликат email (409), невалидный пароль (400)
+- `POST /login` — happy path, неверный пароль (401), lockout после 5 попыток (423)
+- `POST /refresh` — валидный cookie → new access, отсутствие cookie (401)
+- Юнит-тесты для `JwtTokenService` — issuer/audience, expiry, claims shape
+
+### Шаг 5. Экспорт OpenAPI
+
+```
+Ты:  /api-spec-export sprint-01
+```
+
+Скилл собирает API, выгружает swagger в `docs/api/openapi.json` + `docs/api/openapi-sprint-01.json`. Diff:
+
+```
+[additive]
++ POST /api/v1/auth/register
++ POST /api/v1/auth/login
++ POST /api/v1/auth/refresh
++ POST /api/v1/auth/logout
++ schema: AuthResponse, RegisterRequest, LoginRequest
+```
+
+Frontend теперь может `/api-client auth ./docs/api/openapi.json` без поднятого dev-сервера.
+
+### Шаг 6. Ревью и shipping
+
+```
+Ты:  /pr-review
+```
+
+Параллельно `code-reviewer`, `security-reviewer`, `performance-reviewer`. Сводный отчёт:
+
+```
+## PR Review: feature/auth
+
+src/Application/Auth/Handlers/LoginHandler.cs:42:
+  [perf] N+1: UserManager.GetClaimsAsync вызывается в цикле (fix: bulk query)
+
+src/API/Controllers/AuthController.cs:18:
+  [sec] Refresh token читается из request.Cookies без validation flag
+        (fix: проверить HttpOnly + Secure + SameSite=Strict при выдаче)
+
+src/Infrastructure/Auth/JwtTokenService.cs:24:
+  [code] HMACSHA256 hardcoded — вынести в options
+```
+
+Чинишь.
+
+```bash
+dotnet build
+dotnet test
+dotnet format --verify-no-changes
+```
+
+```
+Ты:  /ship "feat: add JWT auth (FR-US-001)"
+```
+
+`/ship` показывает diff, предлагает файлы, пишет commit message по стилю репо, пушит, создаёт PR с `Refs #10`. На каждом шаге подтверждение.
+
+`block-dangerous-commands.sh` заблокирует `push --force` или push в `main`.
+
+## 3. Чем backend отличается от frontend workflow
+
+| Аспект | Backend (.NET) | Frontend (Next.js) |
+|---|---|---|
+| Дизайн-агент | `api-designer` (DTOs, controllers, MediatR) | `frontend-designer` (UI, токены, FSD) |
+| Контракт-обмен | `/api-spec-export` swagger → `docs/api/` | `/api-client` swagger → Axios + Zod + hooks |
+| Format hook | `dotnet format` | `prettier --write` |
+| Lint hook | `dotnet build` warnings (TreatWarningsAsErrors) | `next lint --fix` (после prettier) |
+| Тест-стек | xUnit + WebApplicationFactory + Testcontainers | Vitest + RTL + MSW |
+| Boundary mock | mock DbContext / Identity или Testcontainers Postgres | MSW на `/api/v1/*` |
+| Артефакты | OpenAPI spec, EF migrations | bundle size, RSC/client разметка |
+| Слои | Clean Architecture (API → Application → Domain → Infrastructure) | FSD (app → features → entities → shared) |
+| Performance focus | EF Core N+1, async/await, аллокации | re-renders, useMemo, dynamic imports |
+| Дополнительная политика | EF migrations не редактируем руками | RSC vs `'use client'` |
+
+## 4. Контракт-обмен с frontend
+
+**Цикл при изменении API:**
+
+1. `api-designer` спроектировал → реализовал → тесты зелёные.
+2. `/api-spec-export <tag>` — выгрузил `docs/api/openapi.json` + immutable snapshot.
+3. Закоммитил вместе с feature: `feat: add ... + docs(api): export openapi <tag>` (или отдельный commit).
+4. На фронтенде: `/api-client <domain> ./path/to/openapi.json` → новый/обновлённый slice.
+5. Если diff `[breaking]` — флагнуть в PR description, договориться о порядке мержа (backend first, потом frontend).
+
+## 5. Полезные ссылки
+
+- Канон стека: [architecture/docs/architecture/technical/tech-stack.md](https://github.com/COOKieProjectTeam/architecture/blob/main/docs/architecture/technical/tech-stack.md)
+- Требования: [architecture/docs/requirements/FRS.md](https://github.com/COOKieProjectTeam/architecture/blob/main/docs/requirements/FRS.md)
+- Формат issue: [architecture/docs/process/github-issue-format.md](https://github.com/COOKieProjectTeam/architecture/blob/main/docs/process/github-issue-format.md)
+- Org Project: [COOKieProjectTeam/projects/2](https://github.com/orgs/COOKieProjectTeam/projects/2)
+- Frontend mirror: [cookie-frontend/docs/workflow-frontend.md](https://github.com/COOKieProjectTeam/cookie-frontend/blob/main/docs/workflow-frontend.md)


### PR DESCRIPTION
## Summary

- New `/api-spec-export` skill — exports the live OpenAPI spec to `docs/api/openapi.json` (plus immutable per-tag snapshots). Pairs with frontend `/api-client` so the frontend can consume a checked-in spec instead of hitting a live dev server.
- `docs/workflow-backend.md` — end-to-end reference: agents, skills, hooks, rules + worked example for BE#10 (JWT auth) and the contract-exchange cycle with frontend.
- `CLAUDE.md` fix: stale `docs/technical/tech-stack.md` → `docs/architecture/technical/tech-stack.md` (mirror of frontend PR #28).

## Test plan

- [ ] Skim `.claude/skills/api-spec-export/SKILL.md` — schema fields valid, both export strategies (CLI + runtime curl) make sense
- [ ] Skim `docs/workflow-backend.md` — tables and code blocks render
- [ ] `CLAUDE.md` line 20 — path is `docs/architecture/technical/tech-stack.md`
- [ ] Once API scaffold lands (BE#23), run `/api-spec-export v1` end-to-end and verify `docs/api/openapi.json` is produced