### PR TITLE
fix(hooks): security hardening — probe removal, input sanitization

### DIFF
--- a/.claude/hooks/block-dangerous-commands.sh
+++ b/.claude/hooks/block-dangerous-commands.sh
@@ -16,11 +16,7 @@ emit_deny() {
 }
 
 INPUT=$(cat)
-_PY=""
-_pycand=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)
-if [ -n "$_pycand" ] && printf '' | "$_pycand" -c "pass" >/dev/null 2>&1; then
-  _PY="$_pycand"
-fi
+_PY=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)
 if [ -n "$_PY" ]; then
   COMMAND=$(printf '%s' "$INPUT" | "$_PY" -c \
     "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('command',''))" \
@@ -39,6 +35,7 @@ if GIT_DEFAULT=$(git config --get init.defaultBranch 2>/dev/null) && [ -n "$GIT_
   DEFAULT_BRANCHES="$DEFAULT_BRANCHES,$GIT_DEFAULT"
 fi
 PROTECTED_BRANCHES="${CLAUDE_PROTECTED_BRANCHES:-$DEFAULT_BRANCHES}"
+PROTECTED_BRANCHES=$(printf '%s' "$PROTECTED_BRANCHES" | tr -cd 'a-zA-Z0-9,/_-')
 # Build a regex alternation: main|master|develop|...
 BR_REGEX=$(printf '%s' "$PROTECTED_BRANCHES" | tr ',' '\n' | awk 'NF{printf "%s%s",sep,$0; sep="|"}')
 
@@ -50,10 +47,12 @@ if contains_cmd '(^|[;&|()]+[[:space:]]*)git[[:space:]]+push'; then
   # Explicit refspec to a protected branch (origin main, :main, HEAD:main, remote branch)
   if contains_cmd "git[[:space:]]+push[[:space:]]+[^[:space:]]+[[:space:]]+([^[:space:]]*:)?($BR_REGEX)(\$|[[:space:]])"; then
     MATCHED_BRANCH=$(printf '%s' "$COMMAND" | grep -oE "($BR_REGEX)(\$|[[:space:]])" | head -1 | tr -d '[:space:]')
+    MATCHED_BRANCH="${MATCHED_BRANCH:0:64}"
     emit_deny "Blocked: push to protected branch '${MATCHED_BRANCH:-main}'. Use a feature branch and open a PR."
   fi
   if contains_cmd "git[[:space:]]+push.*:($BR_REGEX)(\$|[[:space:]])"; then
     MATCHED_BRANCH=$(printf '%s' "$COMMAND" | grep -oE ":($BR_REGEX)(\$|[[:space:]])" | head -1 | tr -d ': [:space:]')
+    MATCHED_BRANCH="${MATCHED_BRANCH:0:64}"
     emit_deny "Blocked: push to protected branch '${MATCHED_BRANCH:-main}' via refspec. Use a feature branch and open a PR."
   fi
   # Bare `git push` while on protected branch

--- a/.claude/hooks/format-on-save.sh
+++ b/.claude/hooks/format-on-save.sh
@@ -6,11 +6,7 @@
 # (requires both the binary AND a config file).
 
 INPUT=$(cat)
-_PY=""
-_pycand=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)
-if [ -n "$_pycand" ] && printf '' | "$_pycand" -c "pass" >/dev/null 2>&1; then
-  _PY="$_pycand"
-fi
+_PY=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)
 if [ -n "$_PY" ]; then
   FILE_PATH=$(printf '%s' "$INPUT" | "$_PY" -c \
     "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))" \
@@ -22,6 +18,7 @@ else
     | head -1 || true)
 fi
 
+FILE_PATH="${FILE_PATH%%$'\n'*}"
 if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
   exit 0
 fi

--- a/.claude/hooks/scan-secrets.sh
+++ b/.claude/hooks/scan-secrets.sh
@@ -4,11 +4,7 @@
 # Exit 2 = block. Exit 0 = allow.
 
 INPUT=$(cat)
-_PY=""
-_pycand=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)
-if [ -n "$_pycand" ] && printf '' | "$_pycand" -c "pass" >/dev/null 2>&1; then
-  _PY="$_pycand"
-fi
+_PY=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)
 
 if [ -n "$_PY" ]; then
   TOOL_NAME=$(printf '%s' "$INPUT" | "$_PY" -c \

--- a/.claude/hooks/warn-large-files.sh
+++ b/.claude/hooks/warn-large-files.sh
@@ -4,11 +4,7 @@
 # Exit 2 = block the action. Exit 0 = allow.
 
 INPUT=$(cat)
-_PY=""
-_pycand=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)
-if [ -n "$_pycand" ] && printf '' | "$_pycand" -c "pass" >/dev/null 2>&1; then
-  _PY="$_pycand"
-fi
+_PY=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)
 if [ -n "$_PY" ]; then
   FILE_PATH=$(printf '%s' "$INPUT" | "$_PY" -c \
     "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))" \


### PR DESCRIPTION
## Summary

- Replace 4-line python-probe block with one-liner (`command -v` only) in all hooks — removes redundant `printf '' | python -c "pass"` health check that adds ~10 ms per hook invocation
- `format-on-save.sh`: strip embedded newline from `FILE_PATH` before file-exists check
- `block-dangerous-commands.sh`: sanitize `CLAUDE_PROTECTED_BRANCHES` env var input (allow only `[a-zA-Z0-9,/_-]`)
- `block-dangerous-commands.sh`: cap `MATCHED_BRANCH` to 64 chars to prevent oversized deny messages

## Files changed

- `.claude/hooks/block-dangerous-commands.sh`
- `.claude/hooks/format-on-save.sh`
- `.claude/hooks/scan-secrets.sh`
- `.claude/hooks/warn-large-files.sh`

## Test plan

- [x] `bash -n .claude/hooks/*.sh` — all syntax OK
- [ ] Trigger each hook manually and verify no regression